### PR TITLE
Allow log prettifier to download game logs from this server.

### DIFF
--- a/gdt/logproxy/logproxy_handler.py
+++ b/gdt/logproxy/logproxy_handler.py
@@ -14,4 +14,5 @@ class ProxyHandler(tornado.web.RequestHandler):
     def _download_log(self, path):
         url = urllib.parse.urljoin(self.upstream_base, path)
         r = requests.get(url, timeout=30)
+        r.raise_for_status()
         return r.text

--- a/gdt/logproxy/logproxy_handler.py
+++ b/gdt/logproxy/logproxy_handler.py
@@ -1,0 +1,17 @@
+import requests
+import tornado
+import urllib.parse
+
+class ProxyHandler(tornado.web.RequestHandler):
+    def initialize(self, upstream_base):
+        self.upstream_base = upstream_base
+
+    def get(self, path):
+        game_log = self._download_log(path)
+        self.set_header('Content-Type', 'text/plain')
+        self.write(game_log)
+
+    def _download_log(self, path):
+        url = urllib.parse.urljoin(self.upstream_base, path)
+        r = requests.get(url, timeout=30)
+        return r.text

--- a/start_servers.py
+++ b/start_servers.py
@@ -67,6 +67,7 @@ class SecureApplication(tornado.web.Application):
             (r"/leaderboard", RedirectHandler),
             (r"/leaderboard/", RedirectHandler),
             (r"/static/(.*)", RedirectHandler),
+            (r"/game_logs/(.*)", RedirectHandler),
 
             (r"/query/leaderboard", LeaderboardQueryNobots),
             (r"/query/gokoproratingquery", GokoProRatingQuery),

--- a/start_servers.py
+++ b/start_servers.py
@@ -20,6 +20,7 @@ from gdt.ratings.leaderboard_handler import LeaderboardHandler
 from gdt.ratings.leaderboard_query import LeaderboardQuery
 from gdt.logsearch.logsearch_handler import SearchHandler
 from gdt.kingviz.kingviz_handler import KingdomHandler
+from gdt.logproxy.logproxy_handler import ProxyHandler
 
 from gdt.ratings.assess import GokoProRatingQuery
 
@@ -37,6 +38,7 @@ class InsecureApplication(tornado.web.Application):
             (r"/leaderboard", LeaderboardHandlerNobots),
             (r"/leaderboard/", LeaderboardHandlerNobots),
             (r"/static/(.*)", DocumentSFH, {"path": "web/static"}),
+            (r"/game_logs/(.*)", ProxyHandler, {"upstream_base": "http://dominion-game-logs.s3.amazonaws.com/game_logs/"}),
         ]
         tornado.web.Application.__init__(
             self, handlers

--- a/web/static/logprettifier.html
+++ b/web/static/logprettifier.html
@@ -637,6 +637,7 @@ if (!filename) {
     document.getElementById('y').innerHTML='<h1>Put log address above</h1>';
     return;
 }
+filename = filename.replace('http://dominion-game-logs.s3.amazonaws.com/game_logs/', '/game_logs/')
 xhr.open('GET', filename, true);
 xhr.onreadystatechange= function() {
     document.getElementById('y').innerHTML='<h1>Loading '+this.readyState+'...</h1>';

--- a/web/static/logprettifier.html
+++ b/web/static/logprettifier.html
@@ -638,6 +638,7 @@ if (!filename) {
     return;
 }
 filename = filename.replace('http://dominion-game-logs.s3.amazonaws.com/game_logs/', '/game_logs/')
+filename = filename.replace('https://dominion-game-logs.s3.amazonaws.com/game_logs/', '/game_logs/')
 xhr.open('GET', filename, true);
 xhr.onreadystatechange= function() {
     document.getElementById('y').innerHTML='<h1>Loading '+this.readyState+'...</h1>';


### PR DESCRIPTION
This maps `/game_logs/` to  `http://dominion-game-logs.s3.amazonaws.com/game_logs/20151119/log.0.1447919754143.txt` so the log prettifier's XHR request is not cross domain.

The log prettifier itself removes `http://dominion-game-logs.s3.amazonaws.com` or `https://dominion-game-logs.s3.amazonaws.com` from the filename so links to the prettifier can stay the same and so log URLs can be copy and pasted from the game's "On the Web" link.
