### PR TITLE
Add Jack's name with spaces to type map.

### DIFF
--- a/web/static/logprettifier.html
+++ b/web/static/logprettifier.html
@@ -233,6 +233,7 @@ var types = {
 'Ironmonger':'action',
 'Ironworks':'action',
 'JackOfAllTrades':'action',
+'Jack of All Trades':'action',
 'Jester':'action',
 'Junk Dealer':'action',
 'King\'s Court':'action',


### PR DESCRIPTION
Closes issue with the Jack of All Trade's name causing an exception in the log prettifier.
